### PR TITLE
cli(wthru): add derive subcommand; docs: quick tips

### DIFF
--- a/rpc/thru-cli/README.md
+++ b/rpc/thru-cli/README.md
@@ -6,6 +6,35 @@ A command-line interface for interacting with the Thru blockchain network. The T
 
 See the [Setting Up Thru Devkit](https://docs.thru.org/program-development/setting-up-thru-devkit) guide for installation and usage instructions.
 
+## Quick tips and examples
+
+- Keys
+  - Generate: `thru-cli keys generate mykey`
+  - Add (hex, overwrite): `thru-cli keys add --overwrite mykey <64-hex-privkey>`
+- Accounts
+  - Create: `thru-cli account create mykey`
+  - Info: `thru-cli getaccountinfo mykey`
+- Transfers
+  - Native: `thru-cli transfer airdrop sink 123`
+- Token (custom mint)
+  - Initialize mint: `thru-cli token initialize-mint <creator-ta> --decimals 6 TICKER <32B-hex-seed> --fee-payer <key>`
+  - Initialize token account: `thru-cli token initialize-account <mint> <owner-ta> <32B-hex-seed> --fee-payer <key>`
+  - Mint to: `thru-cli token mint-to <mint> <account> <authority-ta> <amount> --fee-payer <key>`
+  - Transfer: `thru-cli token transfer <from-account> <to-account> <amount> --fee-payer <key>`
+- WTHRU
+  - Derive mint/vault (new): `thru-cli wthru derive`
+  - Initialize: `thru-cli wthru initialize --fee-payer <key>`
+  - Deposit (wrap): `thru-cli wthru deposit <dest-token-account> <lamports> --fee-payer <key>`
+- Name Service & Registrar
+  - Derive registrar for root: `thru-cli nameservice derive-registrar-account <root>`
+  - Initialize base root: `thru-cli nameservice init-root <root> --fee-payer <key>`
+  - Initialize registrar: `thru-cli registrar initialize-registry <registrar> <treasurer_token_acc> <mint> <price> <root> --fee-payer <key>`
+
+Notes
+
+- For `account compress|decompress`, the fee payer is a positional argument: `thru-cli account compress <target-account> [fee_payer]`. (Named flag `--fee-payer` is not supported.)
+- Many commands accept key names (from config) or `ta...` addresses; for seeds use 32-byte hex.
+
 ## License
 
 This project is licensed under the Apache License 2.0.

--- a/rpc/thru-cli/src/cli.rs
+++ b/rpc/thru-cli/src/cli.rs
@@ -1392,6 +1392,18 @@ pub enum WthruCommands {
         #[arg(long = "token-program")]
         token_program: Option<String>,
     },
+
+    /// Derive WTHRU mint and vault addresses
+    #[command(name = "derive")]
+    Derive {
+        /// Override WTHRU program address (ta... or hex)
+        #[arg(long = "program")]
+        program: Option<String>,
+
+        /// Override token program address (ta... or hex)
+        #[arg(long = "token-program")]
+        token_program: Option<String>,
+    },
 }
 
 /// Developer tools subcommands

--- a/tools/thru-keygen/Cargo.toml
+++ b/tools/thru-keygen/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "thru-keygen"
+version = "0.1.0"
+edition = "2024"
+description = "Lightweight key generator for Thru (prints private key, pubkey, address)"
+
+[dependencies]
+thru-base = { version = "0.1.0", path = "../../rpc/thru-base" }
+hex = "0.4"
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.10"

--- a/tools/thru-keygen/src/main.rs
+++ b/tools/thru-keygen/src/main.rs
@@ -1,0 +1,98 @@
+use std::env;
+
+use serde_json::json;
+use thru_base::{KeyPair, tn_tools::Pubkey};
+use sha2::{Digest, Sha256};
+
+fn create_program_defined_account_address(owner: &[u8; 32], is_ephemeral: bool, seed: &[u8; 32]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(owner);
+    hasher.update(&[if is_ephemeral { 1u8 } else { 0u8 }]);
+    hasher.update(seed);
+    let hash = hasher.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&hash[..32]);
+    out
+}
+
+fn pad_seed(seed: &[u8]) -> [u8; 32] {
+    let mut padded = [0u8; 32];
+    let len = seed.len().min(32);
+    padded[..len].copy_from_slice(&seed[..len]);
+    padded
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    // Modes:
+    //   1) No args: generate a fresh keypair
+    //   2) --from-hex <64hex>: derive address/pubkey from an existing private key
+    //   3) --derive-wthru-mint <token_program_ta> <wthru_program_ta>: print WTHRU mint & vault addresses
+    if args.len() >= 2 && args[1] == "--derive-wthru-mint" {
+        if args.len() < 4 {
+            eprintln!("usage: thru-keygen --derive-wthru-mint <token_program> <wthru_program>");
+            std::process::exit(2);
+        }
+        let token_prog = &args[2];
+        let wthru_prog = &args[3];
+        let token_pub = Pubkey::new(token_prog.clone())
+            .and_then(|p| p.to_bytes().map_err(|e| e.into()))
+            .expect("invalid token program pubkey");
+        let wthru_pub = Pubkey::new(wthru_prog.clone())
+            .and_then(|p| p.to_bytes().map_err(|e| e.into()))
+            .expect("invalid wthru program pubkey");
+
+        // mint seed = "wthru" padded to 32
+        let mint_seed = pad_seed(b"wthru");
+        // derived_seed = sha256(wthru_program || mint_seed)
+        let mut hasher = Sha256::new();
+        hasher.update(&wthru_pub);
+        hasher.update(&mint_seed);
+        let hash = hasher.finalize();
+        let mut derived_seed = [0u8; 32];
+        derived_seed.copy_from_slice(&hash[..32]);
+        // mint = create_program_defined_account_address(token_program, false, derived_seed)
+        let mint_bytes = create_program_defined_account_address(&token_pub, false, &derived_seed);
+        // vault = create_program_defined_account_address(wthru_program, false, pad_seed("vault"))
+        let vault_seed = pad_seed(b"vault");
+        let vault_bytes = create_program_defined_account_address(&wthru_pub, false, &vault_seed);
+
+        let mint_addr = Pubkey::from_bytes(&mint_bytes).to_string();
+        let vault_addr = Pubkey::from_bytes(&vault_bytes).to_string();
+        let out = json!({
+            "mint": mint_addr,
+            "vault": vault_addr,
+            "token_program": token_prog,
+            "wthru_program": wthru_prog,
+        });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+        return;
+    }
+
+    let result = if args.len() >= 3 && args[1] == "--from-hex" {
+        let hex_pk = &args[2];
+        KeyPair::from_hex_private_key("key", hex_pk)
+            .map_err(|e| format!("failed to derive from hex: {}", e))
+    } else {
+        KeyPair::generate("key").map_err(|e| format!("failed to generate key: {}", e))
+    };
+
+    match result {
+        Ok(keypair) => {
+            let private_key_hex = hex::encode(keypair.private_key);
+            let public_key_hex = keypair.public_key_hex();
+            let address = keypair.public_key_str();
+            let out = json!({
+                "private_key_hex": private_key_hex,
+                "public_key_hex": public_key_hex,
+                "address": address,
+            });
+            println!("{}", serde_json::to_string_pretty(&out).unwrap());
+        }
+        Err(err) => {
+            eprintln!("{}", err);
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds:

- cli(wthru): New `wthru derive` subcommand to print WTHRU mint & vault PDAs based on config (or overrides).
- docs(cli): Quick tips and examples for keys, accounts, native transfer, token, wthru, and registrar flows.
- docs(agent): Rangkuman agent README updated with common commands and caveats.
- helper(tooling): Lightweight `thru-keygen` dev tool including `--derive-wthru-mint` mode.

Why:
- Frequently needed when testing WTHRU / token flows without custom code.
- Clarifies usage pitfalls: positional fee payer for `account compress/decompress`, boolean flag for `keys add --overwrite`.

Tested against alphanet:
- Derived WTHRU addresses match on-chain program logic.
- Token/WTHRU/Registrar flows exercised successfully.

No breaking changes.