### PR TITLE
fix stale docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Thru is a high-performance blockchain network implementation featuring a custom 
 
 To start developing programs for Thru, see our comprehensive guide:
 
-**[Setting Up Thru Devkit](https://docs.thru.org/program-development/setting-up-thru-devkit)**
+**[Setting Up Thru Devkit](https://thru.org/docs/program-development/setting-up-thru-devkit/)**
 
 ## Documentation
 
-- [Thru Documentation](https://docs.thru.org)
-- [Program Development Guide](https://docs.thru.org/program-development)
+- [Thru Documentation](https://thru.org/docs/)
+- [Program Development Quickstart](https://thru.org/docs/program-development/building-a-c-program/)
 
 ## License
 

--- a/rpc/cli/crates/thru-core/templates/c/README.md
+++ b/rpc/cli/crates/thru-core/templates/c/README.md
@@ -55,7 +55,7 @@ thru program create <seed> build/thruvm/bin/{{PROGRAM_NAME}}_c.bin
 Edit `examples/{{PROGRAM_NAME}}.c` to modify your program logic.
 
 For more information on the Thru C SDK, see the SDK documentation at:
-https://docs.thru.org/program-development/setting-up-thru-devkit
+https://thru.org/docs/program-development/setting-up-thru-devkit/
 
 ## License
 

--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -21,7 +21,7 @@ This is the C SDK for developing Thru programs.
 
 ## Building Your First Program
 
-Follow the [Developing a C Program](https://docs.thru.org/program-development/building-a-c-program) guide in the Thru docs to get started developing your first program.
+Follow the [Developing a C Program](https://thru.org/docs/program-development/building-a-c-program/) guide in the Thru docs to get started developing your first program.
 
 ## Custom Installation
 


### PR DESCRIPTION
This updates a few README links that still pointed at the old docs.thru.org host.

The old URLs now redirect through stale routes, and one of them falls through to an invalid thru.org:8080 URL. These links now point directly at the current thru.org/docs pages instead.

Checked the updated setup and C quickstart links and both return 200.