### PR TITLE
add root gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Rust
+target/
+
+# Node
+node_modules/
+.pnpm-store/
+
+# Build and test output
+dist/
+build/
+out/
+coverage/
+.nyc_output/
+.esbuild/
+*.tsbuildinfo
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Environment files
+.env
+.env.*.local
+*.local
+
+# Editor and OS files
+.vscode/
+.idea/
+*.sublime-workspace
+*.sublime-project
+*.swp
+*.swo
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Adds a root .gitignore with the common local files this repo can generate: Rust targets, Node dependencies, build output, logs, env files, and editor/OS files.

There are already .gitignore files in a few subdirectories, but nothing at the repo root, so this covers the usual workspace-level noise without changing any source files.

Closes #16