### PR TITLE
fix(sdks): repair rust setup install and deps.sh docs

### DIFF
--- a/sdks/c/README.md
+++ b/sdks/c/README.md
@@ -45,7 +45,7 @@ If you prefer to run the dependency installation manually:
 
 ```bash
 # Install toolchain dependencies
-./deps.sh --thru-dir $HOME fetch check install-c
+../deps.sh --thru-dir $HOME fetch check install-c
 
 # Build and install C SDK
 echo "Installing C SDK to: $HOME/.thru/sdk/c"
@@ -66,5 +66,5 @@ export PATH="$HOME/.thru/sdk/toolchain/bin:$PATH"
 ```
 
 **Build failures:**
-- Ensure all system dependencies are installed: `./deps.sh check`
+- Ensure all system dependencies are installed: `../deps.sh check`
 - Check that RISC-V toolchain is in PATH: `which riscv64-unknown-elf-gcc` 

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -100,7 +100,7 @@ If you prefer to run the dependency installation manually:
 
 ```bash
 # Install toolchain dependencies (same as C SDK)
-./deps.sh --thru-dir $HOME fetch check install-c
+../deps.sh --thru-dir $HOME fetch check install-c
 
 # Build and install C++ SDK
 echo "Installing C++ SDK to: $HOME/.thru/sdk/cpp"
@@ -121,6 +121,6 @@ export PATH="$HOME/.thru/sdk/toolchain/bin:$PATH"
 ```
 
 **Build failures:**
-- Ensure all system dependencies are installed: `./deps.sh check`
+- Ensure all system dependencies are installed: `../deps.sh check`
 - Check that RISC-V toolchain is in PATH: `which riscv64-unknown-elf-g++`
 - C++ programs require the same RISC-V toolchain as C programs 

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -121,7 +121,7 @@ If you prefer to run the dependency installation manually:
 
 ```bash
 # Install Rust and RISC-V target
-./deps.sh --thru-dir $HOME install-rust
+../deps.sh --thru-dir $HOME install-rust
 
 # Source Rust environment
 source $HOME/.cargo/env

--- a/sdks/rust/setup.sh
+++ b/sdks/rust/setup.sh
@@ -20,12 +20,9 @@ echo ""
 # Installing Rust SDK
 echo "Installing Rust SDK to: $THRU_DIR/.thru/sdk/rust"
 mkdir -p "$THRU_DIR/.thru/sdk/rust"
-# Copy Rust SDK files if they exist
-if [ -d "thru-sdk" ]; then
-    cp -r thru-sdk/* "$THRU_DIR/.thru/sdk/rust/"
-fi
+cp -rL "$SCRIPT_DIR"/* "$THRU_DIR/.thru/sdk/rust/"
 
 echo ""
 echo "Rust SDK setup complete!"
 echo "Rust toolchain installed. Source environment: source \$HOME/.cargo/env"
-echo "RISC-V target 'riscv64imac-unknown-none-elf' is now available" 
+echo "RISC-V target 'riscv64imac-unknown-none-elf' is now available"


### PR DESCRIPTION
## Summary
- Fix Rust SDK `setup.sh` to copy the full tree from `SCRIPT_DIR` (was CWD-relative `thru-sdk/` only)
- Point C/C++/Rust Manual Setup docs at `../deps.sh`

## Test plan
- [x] `bash -n sdks/{c,cpp,rust}/setup.sh`
- [x] From `sdks/c`, `../deps.sh --help` works
- [x] `readlink sdks/{c,cpp,rust}/deps.sh` → `../deps.sh`