### PR TITLE
Use SCRIPT_DIR when copying Rust SDK files

### DIFF
--- a/sdks/rust/setup.sh
+++ b/sdks/rust/setup.sh
@@ -21,8 +21,8 @@ echo ""
 echo "Installing Rust SDK to: $THRU_DIR/.thru/sdk/rust"
 mkdir -p "$THRU_DIR/.thru/sdk/rust"
 # Copy Rust SDK files if they exist
-if [ -d "thru-sdk" ]; then
-    cp -r thru-sdk/* "$THRU_DIR/.thru/sdk/rust/"
+if [ -d "$SCRIPT_DIR/thru-sdk" ]; then
+    cp -r "$SCRIPT_DIR/thru-sdk/"* "$THRU_DIR/.thru/sdk/rust/"
 fi
 
 echo ""


### PR DESCRIPTION
- Updated the Rust setup script to copy `thru-sdk` relative to `SCRIPT_DIR`.


The script already resolves its own location using `SCRIPT_DIR`, but the copy step relied on a relative path, making it depend on the current working directory.

Using `SCRIPT_DIR` ensures the SDK files are copied from the script's directory and keeps the behavior consistent with the C and C++ setup scripts.