### PR TITLE
Add ABI unavailable decode hint

### DIFF
--- a/rpc/abi/abi_reflect/src/nested_instruction_data.rs
+++ b/rpc/abi/abi_reflect/src/nested_instruction_data.rs
@@ -2,6 +2,8 @@ use crate::formatter::FormattedReflection;
 use serde_json::{Map, Value as JsonValue};
 
 pub const MAX_NESTED_INSTRUCTION_DEPTH: usize = 15;
+const ABI_UNAVAILABLE_DECODE_HINT: &str =
+    "This transaction executed, but the instruction data could not be decoded because no matching ABI was available for this program.";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NestedInstructionDecodeOptions {
@@ -115,6 +117,7 @@ fn resolve_instruction_data_value<A, F>(
     F: FnMut(&str, &[u8]) -> Result<Option<FormattedReflection>, String>,
 {
     map.remove("decodeError");
+    map.remove("decodeHint");
     map.remove("decodedInstruction");
     map.remove("programAddress");
 
@@ -176,9 +179,10 @@ fn resolve_instruction_data_value<A, F>(
             }
         }
         Ok(None) => {
-            insert_error(
+            insert_error_with_hint(
                 map,
                 format!("ABI unavailable for program {program_address}"),
+                Some(ABI_UNAVAILABLE_DECODE_HINT),
             );
         }
         Err(err) => {
@@ -197,7 +201,20 @@ fn is_instruction_data_value(map: &Map<String, JsonValue>) -> bool {
 }
 
 fn insert_error(map: &mut Map<String, JsonValue>, message: impl Into<String>) {
+    insert_error_with_hint(map, message, None);
+}
+
+fn insert_error_with_hint(
+    map: &mut Map<String, JsonValue>,
+    message: impl Into<String>,
+    hint: Option<&'static str>,
+) {
     map.insert("decodeError".to_string(), JsonValue::String(message.into()));
+    if let Some(hint) = hint {
+        map.insert("decodeHint".to_string(), JsonValue::String(hint.to_string()));
+    } else {
+        map.remove("decodeHint");
+    }
 }
 
 fn parse_hex_bytes(value: &str) -> Result<Vec<u8>, String> {
@@ -392,6 +409,10 @@ mod tests {
         assert_eq!(
             invoke.get("decodeError").and_then(JsonValue::as_str),
             Some("ABI unavailable for program token")
+        );
+        assert_eq!(
+            invoke.get("decodeHint").and_then(JsonValue::as_str),
+            Some("This transaction executed, but the instruction data could not be decoded because no matching ABI was available for this program.")
         );
     }
 

--- a/web/packages/sdk/src/abi/nestedInstructionData.ts
+++ b/web/packages/sdk/src/abi/nestedInstructionData.ts
@@ -1,6 +1,8 @@
 import type { FormattedReflection } from "./types";
 
 export const MAX_NESTED_INSTRUCTION_DEPTH = 15;
+const ABI_UNAVAILABLE_DECODE_HINT =
+  "This transaction executed, but the instruction data could not be decoded because no matching ABI was available for this program.";
 
 export interface NestedInstructionDecodeOptions {
   maxDepth?: number;
@@ -70,6 +72,7 @@ async function resolveInstructionDataValue(
   maxDepth: number,
 ): Promise<void> {
   delete value.decodeError;
+  delete value.decodeHint;
   delete value.decodedInstruction;
   delete value.programAddress;
 
@@ -99,7 +102,11 @@ async function resolveInstructionDataValue(
   try {
     const decoded = await decoder(programAddress, data);
     if (!decoded) {
-      insertError(value, `ABI unavailable for program ${programAddress}`);
+      insertError(
+        value,
+        `ABI unavailable for program ${programAddress}`,
+        ABI_UNAVAILABLE_DECODE_HINT,
+      );
       return;
     }
 
@@ -125,8 +132,13 @@ function isInstructionDataValue(value: JsonObject): boolean {
   );
 }
 
-function insertError(value: JsonObject, message: string): void {
+function insertError(value: JsonObject, message: string, hint?: string): void {
   value.decodeError = message;
+  if (hint) {
+    value.decodeHint = hint;
+  } else {
+    delete value.decodeHint;
+  }
 }
 
 function parseHexBytes(value: string): Uint8Array {

--- a/web/packages/sdk/test/abi/nestedInstructionData.test.ts
+++ b/web/packages/sdk/test/abi/nestedInstructionData.test.ts
@@ -105,6 +105,9 @@ describe("resolveNestedInstructionData", () => {
     expect(missingAbi.value.invoke.decodeError).toBe(
       "ABI unavailable for program token",
     );
+    expect(missingAbi.value.invoke.decodeHint).toBe(
+      "This transaction executed, but the instruction data could not be decoded because no matching ABI was available for this program.",
+    );
   });
 
   it("ignores lookalike objects that were not marked by the InstructionData handler", async () => {


### PR DESCRIPTION
## Summary

Adds a stable `decodeHint` alongside `decodeError` when nested instruction data cannot be decoded because the ABI is missing.

This keeps the existing error string intact while giving Explorer/UI consumers a better tooltip message for the "ABI unavailable" case:

> This transaction executed, but the instruction data could not be decoded because no matching ABI was available for this program.

## Why

When a transaction succeeds but instruction decoding cannot run, the current `ABI unavailable for program ...` text can read like the transaction failed. A separate hint gives the UI enough context to explain that execution and decoding are different concerns.

## Changes

- Adds `decodeHint` for missing ABI cases in the TypeScript SDK resolver.
- Adds the same field in the Rust ABI reflection path.
- Clears stale `decodeHint` values before each decode attempt.
- Extends the existing SDK/Rust test coverage for the missing ABI case.

## Testing

- `git diff --check`
- Attempted `pnpm --filter @thru/sdk test -- nestedInstructionData.test.ts`, but workspace dependency installation stalled on repeated registry fetch failures.
- Could not run Rust tests locally because `cargo` is not installed on this machine.

Closes #27.
