### PR TITLE
fix: cargo test --workspace fails to compile in rpc/cli (missing specs/ path)

### DIFF
--- a/rpc/cli/crates/thru-core/src/feature_gate_registry.rs
+++ b/rpc/cli/crates/thru-core/src/feature_gate_registry.rs
@@ -339,10 +339,8 @@ tracking = "UNTO-1818"
 "#;
 
     fn checked_in_registry() -> FeatureGateRegistry {
-        parse_feature_gate_registry(include_str!(
-            "../../../../../specs/releases/feature-gates-registry.toml"
-        ))
-        .expect("checked-in registry parses")
+        parse_feature_gate_registry(include_str!("../registry/feature-gates-registry.toml"))
+            .expect("checked-in registry parses")
     }
 
     #[test]


### PR DESCRIPTION
`cargo test --workspace` in `rpc/cli` fails to compile because it references
`crates/thru-core/src/../../../../../specs/releases/feature-gates-registry.toml`,
a path that isn't present in this mirror repo. `cargo build` succeeds, but
`cargo test` never compiles — meaning no one cloning this repo can run the
test suite.

This PR points the path to `../registry/feature-gates-registry.toml`, which
is already bundled via `include_str!` (see the comment at line 15: "bundled
so installed CLI binaries do not depend on a source-checkout path").

Verified locally: full workspace now passes — 160 + 3 tests, 0 failures.
