### PR TITLE
fix(wallet): harden base64ToBytes to reject non-canonical padding

### DIFF
--- a/web/packages/wallet/src/encoding.test.ts
+++ b/web/packages/wallet/src/encoding.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { base64ToBytes } from "./encoding";
+
+const hex = (u: Uint8Array) =>
+  Array.from(u, (b) => b.toString(16).padStart(2, "0")).join("");
+
+describe("base64ToBytes", () => {
+  it("decodes canonical inputs (parity with reference encoder)", () => {
+    expect(hex(base64ToBytes(""))).toBe("");
+    expect(hex(base64ToBytes("QQ=="))).toBe("41");
+    expect(hex(base64ToBytes("QUJD"))).toBe("414243");
+    expect(hex(base64ToBytes("aGVsbG8="))).toBe("68656c6c6f");
+    expect(hex(base64ToBytes("AAECAwQF"))).toBe("000102030405");
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(hex(base64ToBytes(" QU\nJD ".trim()))).toBe("414243");
+  });
+
+  // Regression: these previously decoded silently to wrong bytes.
+  it("rejects embedded padding (malleability)", () => {
+    expect(() => base64ToBytes("QQ==QQ==")).toThrow(); // was 41 00 00 41
+    expect(() => base64ToBytes("QUJ=QUJD")).toThrow(); // was 41 42 40 41 42 43
+  });
+
+  it("rejects malformed / non-canonical padding", () => {
+    expect(() => base64ToBytes("QQ===")).toThrow();
+    expect(() => base64ToBytes("=QQQ")).toThrow();
+    expect(() => base64ToBytes("QQ=Q")).toThrow();
+    expect(() => base64ToBytes("QUJE")).not.toThrow();
+    expect(() => base64ToBytes("QUJF")).toThrow(); // non-zero discarded bits
+  });
+
+  it("rejects characters outside the standard alphabet", () => {
+    expect(() => base64ToBytes("QU-D")).toThrow(); // '-' is base64url, not base64
+    expect(() => base64ToBytes("QU@D")).toThrow();
+  });
+});

--- a/web/packages/wallet/src/encoding.ts
+++ b/web/packages/wallet/src/encoding.ts
@@ -1,39 +1,77 @@
-const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const BASE64_ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-const BASE64_LOOKUP = new Map<string, number>(
-  [...BASE64_ALPHABET].map((char, index) => [char, index]),
-);
+const BASE64_LOOKUP: readonly number[] = (() => {
+  // Dense 128-entry table: O(1) lookup, no Map allocation, -1 = invalid.
+  const table = new Array<number>(128).fill(-1);
+  for (let i = 0; i < BASE64_ALPHABET.length; i++) {
+    table[BASE64_ALPHABET.charCodeAt(i)] = i;
+  }
+  return table;
+})();
 
+/**
+ * Decodes standard base64 (RFC 4648) into bytes.
+ *
+ * Strict on purpose: this runs on the signature↔wire boundary (a signed
+ * transaction decoded here must be byte-identical to what the wallet signed),
+ * so any non-canonical input is rejected rather than silently coerced.
+ *
+ * Rejects: characters outside the alphabet, `=` anywhere but as trailing
+ * padding of the final quartet, over-/under-padding, and non-zero tail bits
+ * that a canonical encoder would never emit.
+ */
 export function base64ToBytes(value: string): Uint8Array {
-  const normalized = value.replace(/\s+/g, "");
-  if (normalized.length === 0) return new Uint8Array();
-  if (normalized.length % 4 === 1) {
-    throw new Error("Invalid base64 data");
+  const s = value.replace(/\s+/g, "");
+  if (s.length === 0) return new Uint8Array();
+  if (s.length % 4 !== 0) {
+    // Standard base64 is always a whole number of quartets once padded;
+    // an unpadded remainder of 1 is impossible, 2/3 require explicit `=`.
+    throw new Error("Invalid base64: length is not a multiple of 4");
   }
 
-  const padded = normalized.padEnd(
-    normalized.length + ((4 - (normalized.length % 4)) % 4),
-    "=",
-  );
-  const padding = padded.endsWith("==") ? 2 : padded.endsWith("=") ? 1 : 0;
-  const output = new Uint8Array((padded.length / 4) * 3 - padding);
-  let outIdx = 0;
+  let padding = 0;
+  if (s[s.length - 1] === "=") padding = s[s.length - 2] === "=" ? 2 : 1;
 
-  for (let i = 0; i < padded.length; i += 4) {
-    const chars = padded.slice(i, i + 4);
-    const a = BASE64_LOOKUP.get(chars[0]);
-    const b = BASE64_LOOKUP.get(chars[1]);
-    const c = chars[2] === "=" ? 0 : BASE64_LOOKUP.get(chars[2]);
-    const d = chars[3] === "=" ? 0 : BASE64_LOOKUP.get(chars[3]);
-    if (a === undefined || b === undefined || c === undefined || d === undefined) {
-      throw new Error("Invalid base64 data");
+  const out = new Uint8Array((s.length / 4) * 3 - padding);
+  let o = 0;
+
+  for (let i = 0; i < s.length; i += 4) {
+    const lastQuartet = i + 4 === s.length;
+
+    const c0 = s.charCodeAt(i);
+    const c1 = s.charCodeAt(i + 1);
+    const c2 = s.charCodeAt(i + 2);
+    const c3 = s.charCodeAt(i + 3);
+
+    const a = c0 < 128 ? BASE64_LOOKUP[c0] : -1;
+    const b = c1 < 128 ? BASE64_LOOKUP[c1] : -1;
+    // `=` is only ever legal in the final quartet, positions 3 and/or 4.
+    const cIsPad = lastQuartet && s[i + 2] === "=";
+    const dIsPad = lastQuartet && s[i + 3] === "=";
+    const c = cIsPad ? 0 : c2 < 128 ? BASE64_LOOKUP[c2] : -1;
+    const d = dIsPad ? 0 : c3 < 128 ? BASE64_LOOKUP[c3] : -1;
+
+    if (a < 0 || b < 0 || c < 0 || d < 0) {
+      throw new Error("Invalid base64: illegal character or misplaced padding");
+    }
+    // `xxx=` is legal; `xx=x` is not.
+    if (cIsPad && !dIsPad) {
+      throw new Error("Invalid base64: malformed padding");
+    }
+    // Canonical-form check: bits that padding discards must be zero.
+    if (dIsPad && !cIsPad && (d = 0, (c & 0b0011) !== 0)) {
+      throw new Error("Invalid base64: non-canonical trailing bits");
+    }
+    if (cIsPad && (b & 0b1111) !== 0) {
+      throw new Error("Invalid base64: non-canonical trailing bits");
     }
 
     const chunk = (a << 18) | (b << 12) | (c << 6) | d;
-    if (outIdx < output.length) output[outIdx++] = (chunk >> 16) & 0xff;
-    if (outIdx < output.length) output[outIdx++] = (chunk >> 8) & 0xff;
-    if (outIdx < output.length) output[outIdx++] = chunk & 0xff;
+    out[o++] = (chunk >> 16) & 0xff;
+    if (!cIsPad) out[o++] = (chunk >> 8) & 0xff;
+    if (!dIsPad) out[o++] = chunk & 0xff;
   }
 
-  return output;
+  return out;
 }


### PR DESCRIPTION
The hand-rolled `base64ToBytes` decoder in `packages/wallet/src/encoding.ts` silently accepts non-canonical base64 padding, resulting in malformed byte arrays instead of throwing an error. 

Because this function sits on the signature↔wire boundary (used in `deposit/index.ts` and `ThruChain.ts`), silently coercing invalid input breaks the core invariant that signed bytes must match the wire payload byte-for-byte.

**Changes:**
- Replaced the permissive quartet loop with a strict, single-pass decoder.
- Validates length and enforces that `=` is only legal as trailing padding of the final quartet.
- Rejects non-canonical trailing bits.
- Added comprehensive unit tests targeting malleability vectors.