### PR TITLE
fix(sdk): keep the bit value across a split RLE run

### DIFF
--- a/sdks/c/thru-sdk/c/tn_rle.c
+++ b/sdks/c/thru-sdk/c/tn_rle.c
@@ -51,10 +51,16 @@ tn_rle_encode( tn_rle_t *    rle,
 
     if( bit == current_bit ) {
       if( run_length == 65535 ) {
-        if( rle->run_count >= max_runs ) {
+        /* A run longer than a ushort can hold is split across several entries.
+           Every decoder and the iterator flip the bit value after each run, so a
+           zero-length run has to sit between the pieces to flip it straight back.
+           Without it the continuation decodes as the opposite value: 70000 ones
+           encode to [65535, 4465] and decode as 65535 ones then 4465 zeros. */
+        if( (ulong)rle->run_count + 2UL > (ulong)max_runs ) {
           return TN_RLE_ERR_RUNS_TOO_SMALL;
         }
         rle->runs[ rle->run_count++ ] = 65535;
+        rle->runs[ rle->run_count++ ] = 0;
         run_length                    = 0;
       }
       run_length++;


### PR DESCRIPTION
## The bug

`tn_rle_encode` splits a run longer than a `ushort` can hold into several entries:

```c
if( run_length == 65535 ) {
  if( rle->run_count >= max_runs ) return TN_RLE_ERR_RUNS_TOO_SMALL;
  rle->runs[ rle->run_count++ ] = 65535;
  run_length                    = 0;
}
run_length++;
```

But every consumer flips the bit value after each run, unconditionally:

```c
for( ushort run_idx = 0; run_idx < rle->run_count && bit_pos < max_bits; run_idx++ ) {
  ...
  current_bit = (ushort)( 1U - current_bit );
}
```

So the continuation of a split run is read back as the opposite value. 70000 ones encode to `runs=[65535, 4465]` and decode as 65535 ones followed by 4465 **zeros**.

Nothing reports it. `tn_rle_encode` returns `TN_RLE_SUCCESS`, `tn_rle_total_bits` equals the input bit count, and `out_bit_count` comes back 70000. The corruption is only visible if you compare the bits.

All three consumers are affected identically: `tn_rle_decode`, `tn_rle_decode_bytes` and `tn_rle_iter_next_set`.

**Scope, stated honestly:** the iterator's comment bounds guardian sets at 65535, and at that ceiling `bit_count` never exceeds 65535, so no run can reach the split and the guardian path is not affected. `tn_rle_encode` is a public SDK entry point taking `ulong bit_count` with no cap, and the split branch exists precisely to handle runs past 65535 — it just does not produce something the decoders can read. This is a correctness bug in that branch, not a live exploit against guardian bitsets.

## The fix

Emit a zero-length run between the pieces. Every consumer already handles one correctly: it contributes no bits and flips the value straight back, which is exactly what the continuation needs. `tn_rle_total_bits` is unaffected because it sums run lengths.

Splits then chain, so a run of any length round-trips: 200000 ones become `[65535, 0, 65535, 0, 65535, 0, 3395]`.

The split now needs two slots, so the bounds check reserves two. A caller whose `max_runs` cannot hold both gets `TN_RLE_ERR_RUNS_TOO_SMALL` rather than a write past the end of `runs[]` — with the old check, reserving one slot and writing two would have overrun by one `ushort`.

## Reproducing it

Only `tn_rle.c` and `tn_rle.h` are needed; `-DTHRU_VM=1` takes the SDK include path rather than the firedancer one, so this builds on the host with no toolchain:

```
cc -O1 -DTHRU_VM=1 -I sdks/c/thru-sdk/c -o rle_check rle_check.c sdks/c/thru-sdk/c/tn_rle.c
./rle_check
```

`rle_check.c` round-trips several patterns through both decoders and the iterator:

```
    #include <stdio.h>
    #include <stdlib.h>
    #include <string.h>
    #include "tn_rle.h"
    
    static int  gw(ulong const *b, ulong i){ return (int)((b[i/64] >> (63UL-(i%64UL))) & 1UL); }
    static void sw(ulong *b, ulong i){ b[i/64] |= (1UL << (63UL-(i%64UL))); }
    
    static int fails = 0;
    #define CHECK(c, ...) do{ if(!(c)){ fails++; printf("  FAIL: "); printf(__VA_ARGS__); printf("\n"); } }while(0)
    
    /* pattern: 0 = all ones, 1 = alternating long blocks, 2 = leading zeros then ones */
    static void run_case(char const *name, ulong bits, int pattern){
      ulong words = (bits + 63)/64;
      ulong *in = calloc(words, sizeof(ulong)), *out = calloc(words, sizeof(ulong));
      for(ulong i=0;i<bits;i++){
        int v = pattern==0 ? 1 : pattern==1 ? ((i/70000UL)%2UL)==0 : (i >= 70000UL);
        if(v) sw(in,i);
      }
      ushort max_runs = 64;
      tn_rle_t *rle = tn_rle_new(calloc(1, tn_rle_footprint(max_runs)), max_runs);
    
      int err = tn_rle_encode(rle, max_runs, in, bits);
      CHECK(err==TN_RLE_SUCCESS, "%s: encode err=%d", name, err);
      CHECK(tn_rle_total_bits(rle)==bits, "%s: total_bits=%lu want %lu", name, tn_rle_total_bits(rle), bits);
    
      /* 1. word decoder */
      ulong n=0; err = tn_rle_decode(rle, out, bits, &n);
      CHECK(err==TN_RLE_SUCCESS && n==bits, "%s: decode err=%d n=%lu", name, err, n);
      ulong bad=0, first=(ulong)-1;
      for(ulong i=0;i<bits;i++) if(gw(in,i)!=gw(out,i)){ if(first==(ulong)-1) first=i; bad++; }
      CHECK(bad==0, "%s: tn_rle_decode %lu bits wrong, first at %lu", name, bad, first);
    
      /* 2. byte decoder */
      uchar *bo = calloc((bits+7)/8, 1);
      n=0; err = tn_rle_decode_bytes(rle, bo, bits, &n);
      CHECK(err==TN_RLE_SUCCESS && n==bits, "%s: decode_bytes err=%d n=%lu", name, err, n);
      bad=0; first=(ulong)-1;
      for(ulong i=0;i<bits;i++) if(gw(in,i)!=tn_rle_test_bit(bo,i)){ if(first==(ulong)-1) first=i; bad++; }
      CHECK(bad==0, "%s: tn_rle_decode_bytes %lu bits wrong, first at %lu", name, bad, first);
    
      /* 3. iterator must yield exactly the set-bit indices, in order */
      tn_rle_iter_t it; tn_rle_iter_init(&it, rle);
      ulong idx, expect=0, seen=0; int order_ok=1;
      while((idx = tn_rle_iter_next_set(&it, bits)) != TN_RLE_ITER_DONE){
        while(expect<bits && !gw(in,expect)) expect++;
        if(idx!=expect){ order_ok=0; break; }
        expect++; seen++;
      }
      ulong want=0; for(ulong i=0;i<bits;i++) want += (ulong)gw(in,i);
      CHECK(order_ok, "%s: iterator yielded %lu where %lu expected", name, idx, expect);
      CHECK(seen==want, "%s: iterator yielded %lu set bits, want %lu", name, seen, want);
    
      printf("  %-28s bits=%-7lu runs=%-3u %s\n", name, bits, rle->run_count, fails?"":"ok");
    }
    
    int main(void){
      printf("round-trip through both decoders and the iterator:\n");
      run_case("short run (no split)",      1000,   0);
      run_case("exactly 65535 ones",        65535,  0);
      run_case("65536 ones (first split)",  65536,  0);
      run_case("70000 ones",                70000,  0);
      run_case("200000 ones (two splits)",  200000, 0);
      run_case("alternating 70k blocks",    350000, 1);
      run_case("70k zeros then ones",       140000, 2);
    
      /* the split must respect max_runs rather than overrun the array */
      ushort mr = 1;
      tn_rle_t *r = tn_rle_new(calloc(1, tn_rle_footprint(mr)), mr);
      ulong bits = 70000, words=(bits+63)/64;
      ulong *in = calloc(words, sizeof(ulong));
      for(ulong i=0;i<bits;i++) sw(in,i);
      int err = tn_rle_encode(r, mr, in, bits);
      CHECK(err==TN_RLE_ERR_RUNS_TOO_SMALL, "max_runs=1 should refuse the split, got %d", err);
      printf("  %-28s -> %d (TN_RLE_ERR_RUNS_TOO_SMALL)\n", "max_runs too small", err);
    
      printf(fails ? "\n%d CHECK(s) FAILED\n" : "\nall checks passed\n", fails);
      return fails != 0;
    }
```

Before this change, on `v0.3.14`:

```
  short run (no split)         bits=1000    runs=1   ok
  exactly 65535 ones           bits=65535   runs=1   ok
  FAIL: 65536 ones (first split): tn_rle_decode 1 bits wrong, first at 65535
  FAIL: 65536 ones (first split): tn_rle_decode_bytes 1 bits wrong, first at 65535
  FAIL: 65536 ones (first split): iterator yielded 65535 set bits, want 65536
  FAIL: 70000 ones: tn_rle_decode 4465 bits wrong, first at 65535
  FAIL: 70000 ones: tn_rle_decode_bytes 4465 bits wrong, first at 65535
  FAIL: 70000 ones: iterator yielded 65535 set bits, want 70000
  FAIL: 200000 ones (two splits): tn_rle_decode 68930 bits wrong, first at 65535
  FAIL: alternating 70k blocks: tn_rle_decode 144465 bits wrong, first at 65535
  FAIL: 70k zeros then ones: iterator yielded 0 set bits, want 70000
  ...
18 CHECK(s) FAILED
```

After:

```
  short run (no split)         bits=1000    runs=1   ok
  exactly 65535 ones           bits=65535   runs=1   ok
  65536 ones (first split)     bits=65536   runs=3   ok
  70000 ones                   bits=70000   runs=3   ok
  200000 ones (two splits)     bits=200000  runs=7   ok
  alternating 70k blocks       bits=350000  runs=15  ok
  70k zeros then ones          bits=140000  runs=6   ok
  max_runs too small           -> -1 (TN_RLE_ERR_RUNS_TOO_SMALL)

all checks passed
```

The two cases either side of the boundary — a short run, and a run of exactly 65535 — pass both before and after, so the change does not alter anything that was already correct.

## On a unit test

I did not add one. `config/thru_c.mk` has `make-unit-test` and a `run-unit-test` target, which is clearly where this belongs, but the only machine config in the mirror is `machine/thruvm.mk`: `-nostartfiles -static-pie -e _start` against a custom linker script, so a unit test built here is a RISC-V program rather than a host binary, and I have no way to build or run it. Adding a test file I cannot compile seemed worse than leaving the reproduction above, which runs on any host in a couple of seconds.

Happy to add it under `make-unit-test` if you tell me how the C SDK's tests are built and run against the VM target internally.

---

*Developed with assistance from AI.*
