### PR TITLE
feat(cli): show consumed memory units after execution

### DIFF
--- a/rpc/cli/crates/thru-core/src/commands/txn.rs
+++ b/rpc/cli/crates/thru-core/src/commands/txn.rs
@@ -346,6 +346,7 @@ async fn execute_transaction(
             "signature": transaction_details.signature.as_str(),
             "slot": transaction_details.slot,
             "compute_units_consumed": transaction_details.compute_units_consumed,
+            "memory_units_consumed": transaction_details.memory_units_consumed,
             "state_units_consumed": transaction_details.state_units_consumed,
             "execution_result": transaction_details.execution_result,
             "vm_error": transaction_details.vm_error,
@@ -367,6 +368,10 @@ async fn execute_transaction(
         println!(
             "Compute Units Consumed: {}",
             transaction_details.compute_units_consumed
+        );
+        println!(
+            "Memory Units Consumed: {}",
+            transaction_details.memory_units_consumed
         );
         println!(
             "State Units Consumed: {}",


### PR DESCRIPTION
`txn execute` receives `memory_units_consumed` in the transaction details, but currently leaves it out of both output formats. Print `Memory Units Consumed` in the text result and expose the same value as `transaction_execute.memory_units_consumed` in JSON, consistent with `txn get`.

Checked with `cargo check --locked -p thru-core` and the transaction command unit tests (3 passed). I also verified both output formats locally.

Fixes #36.
