### PR TITLE
fix(abi): use the input length in buffer errors

### DIFF
--- a/rpc/abi/abi_reflect/src/params.rs
+++ b/rpc/abi/abi_reflect/src/params.rs
@@ -46,6 +46,7 @@ impl<'a> ParamExtractor<'a> {
             self.resolver,
             &self.field_params,
             &self.payload_targets,
+            data.len(),
         );
         let mut path = Vec::new();
         walker.process_struct(self.resolved_type, &mut path, data)?;
@@ -599,6 +600,7 @@ mod tests {
 
 struct StructWalker<'a> {
     type_name: &'a str,
+    buffer_len: usize,
     resolver: &'a TypeResolver,
     field_params: &'a BTreeMap<String, Vec<&'a str>>,
     params: ParamMap,
@@ -613,9 +615,11 @@ impl<'a> StructWalker<'a> {
         resolver: &'a TypeResolver,
         field_params: &'a BTreeMap<String, Vec<&'a str>>,
         payload_targets: &'a BTreeMap<&'a str, String>,
+        buffer_len: usize,
     ) -> Self {
         Self {
             type_name,
+            buffer_len,
             resolver,
             field_params,
             params: ParamMap::new(),
@@ -1199,7 +1203,7 @@ impl<'a> StructWalker<'a> {
         ReflectError::BufferTooSmall {
             type_name: self.type_name.to_string(),
             required: required as u128,
-            available: required,
+            available: self.buffer_len as u64,
         }
     }
 }

--- a/rpc/abi/abi_reflect/tests/buffer_size_tests.rs
+++ b/rpc/abi/abi_reflect/tests/buffer_size_tests.rs
@@ -1,0 +1,32 @@
+use abi_gen::abi::file::AbiFile;
+use abi_gen::abi::resolved::TypeResolver;
+use abi_reflect::{ReflectError, Reflector};
+
+#[test]
+fn reports_actual_input_length_for_truncated_dynamic_array() {
+    let abi: AbiFile = serde_yml::from_str(include_str!("fixtures/buffer_size.abi.yaml"))
+        .expect("parse ABI fixture");
+    let mut resolver = TypeResolver::new();
+    for typedef in abi.types {
+        resolver.add_typedef(typedef);
+    }
+    resolver.resolve_all().expect("resolve ABI fixture");
+    let reflector = Reflector::new(resolver).expect("build reflector");
+
+    let mut bytes = 12u32.to_le_bytes().to_vec();
+    bytes.extend_from_slice(&[0; 12]);
+    let error = reflector.reflect(&bytes, "Payload").unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "type 'Payload' requires 48 bytes but only 16 available"
+    );
+    assert!(matches!(
+        error,
+        ReflectError::BufferTooSmall {
+            required: 48,
+            available: 16,
+            ..
+        }
+    ));
+}

--- a/rpc/abi/abi_reflect/tests/fixtures/buffer_size.abi.yaml
+++ b/rpc/abi/abi_reflect/tests/fixtures/buffer_size.abi.yaml
@@ -1,0 +1,24 @@
+abi:
+  package: tests.buffer_size
+  name: buffer-size
+  abi-version: 1
+  package-version: 1.0.0
+  description: Buffer size regression fixture
+  imports: []
+types:
+  - name: Payload
+    kind:
+      struct:
+        packed: true
+        fields:
+          - name: data_len
+            field-type:
+              primitive: u32
+          - name: values
+            field-type:
+              array:
+                size:
+                  field-ref:
+                    path: [data_len]
+                element-type:
+                  primitive: u32


### PR DESCRIPTION
When parameter extraction runs out of bytes while reading a runtime-sized array, `BufferTooSmall` copies the required byte count into `available`. Keep the original input length in `StructWalker` and use that value instead. The reproduction from #46 now reports `requires 48 bytes but only 16 available`.

The regression test exercises the public `Reflector` API with the ABI and input shape from the issue. `cargo test --locked -p thru-abi-reflect` passes with 89 tests and one existing ignored test; clippy reports only the existing warnings.

Fixes #46.
